### PR TITLE
Fix Quotation structure casting to json

### DIFF
--- a/lib/invest_tinkoff/v2/quotation.rb
+++ b/lib/invest_tinkoff/v2/quotation.rb
@@ -14,4 +14,8 @@ class InvestTinkoff::V2::Quotation
       nano
     )
   end
+
+  def to_json(*)
+    to_h.to_json
+  end
 end


### PR DESCRIPTION
Using ruby `3.2.2`
Posting `create_order` request. `Struct` invalidates request.

https://github.com/blackchestnut/invest_tinkoff/blob/master/lib/invest_tinkoff/client_base.rb#L31
```ruby
=> body.to_json

"{ ..., \"price\":\"#<struct InvestTinkoff::V2::Quotation units=200, nano=0>\", ...}"
```

Added custom json type cast to Quotation